### PR TITLE
chore: cleanup context paths at examples/microservices skaffold.yml

### DIFF
--- a/examples/microservices/skaffold.yaml
+++ b/examples/microservices/skaffold.yaml
@@ -3,14 +3,14 @@ kind: Config
 build:
   artifacts:
     - image: leeroy-web
-      context: ./leeroy-web/
+      context: leeroy-web
     - image: leeroy-app
-      context: ./leeroy-app/
+      context: leeroy-app
 deploy:
   kubectl:
     manifests:
-      - ./leeroy-web/kubernetes/*
-      - ./leeroy-app/kubernetes/*
+      - leeroy-web/kubernetes/*
+      - leeroy-app/kubernetes/*
 portForward:
   - resourceType: deployment
     resourceName: leeroy-web


### PR DESCRIPTION
<!-- Thank you for your contribution! -->


**Description**
<!-- Describe your changes here. The more detail, the easier the review! -->
removed the `./` at the `context` paths and `kubectl manifests` for the `examples/microservices/skaffold.yml` file. most of the example skaffold.yml files does not have a `./` as suffix at the filepaths.
